### PR TITLE
removed extra parenthesis from readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cb.__call(
             }
         );
     }
-));
+);
 ```
 
 Now you need to add a PIN box to your website. 


### PR DESCRIPTION
tiny tiny change to the readme - the oauth_requestToken authentication example call had an extra `)` at the end.
