### PR TITLE
Fix array bad behavior in iOS

### DIFF
--- a/codebird.js
+++ b/codebird.js
@@ -41,7 +41,7 @@
 /**
  * Array.indexOf polyfill
  */
-if (! Array.indexOf) {
+if (! Array.prototype.indexOf) {
     Array.prototype.indexOf = function (obj, start) {
         for (var i = (start || 0); i < this.length; i++) {
             if (this[i] === obj) {


### PR DESCRIPTION
This behavior brokes array normal behavior. Using Array.prototype.indexOf fix the issue
