### PR TITLE
Fix 401 for second (or later) requests

### DIFF
--- a/codebird.js
+++ b/codebird.js
@@ -337,6 +337,10 @@ var Codebird = function () {
         case "oauth2_token":
             return this[fn](callback);
         }
+        //reset token when requesting a new token (causes 401 for signature error on 2nd+ requests)
+        if (fn === "oauth_requestToken") {
+            setToken(null, null);
+        }
         // parse parameters
         var apiparams = {};
         if (typeof params === "object") {


### PR DESCRIPTION
Without this change, if you make a login request (regardless of success/failure/whatever) and then request another request token, the token saved from the previous request is appended to the new token request, causing the signature not to match, and Twitter returns a 401.

This change resets the token every time you make a new-token request.
