### PR TITLE
Fix XHR in Safari

### DIFF
--- a/codebird.js
+++ b/codebird.js
@@ -1219,7 +1219,7 @@ var Codebird = function () {
         var xml = null;
         if (typeof window === "object"
             && window
-            && typeof window.XMLHttpRequest === "function"
+            && typeof window.XMLHttpRequest !== "undefined"
         ) {
             xml = new window.XMLHttpRequest();
         } else if (typeof require === "function"


### PR DESCRIPTION
codebird-js was silently failing in Safari. `typeof window.XMLHttpRequest` is apparently `"object"` in Safari, which caused the returned XHR object to be null and silently ended _callApi.
