### PR TITLE
Update codebird.js

### DIFF
--- a/codebird.js
+++ b/codebird.js
@@ -376,6 +376,7 @@ var Codebird = function () {
                 "users/contributors",
                 "users/profile_banner",
                 "users/search",
+                "users/lookup",
                 "users/show",
                 "users/suggestions",
                 "users/suggestions/:slug",
@@ -443,7 +444,6 @@ var Codebird = function () {
                 "statuses/retweet/:id",
                 "statuses/update",
                 "statuses/update_with_media", // deprecated, use media/upload
-                "users/lookup",
                 "users/report_spam",
 
                 // Internal


### PR DESCRIPTION
"users/lookup" is a GET method. When trying to use as post I get an error "POST https://api.jublo.net/codebird/1.1/users/lookup.json 404 (Not Found)"