### PR TITLE
Removed extra ' on line 607

### DIFF
--- a/codebird.es7.js
+++ b/codebird.es7.js
@@ -604,7 +604,7 @@
             } else {
               key = eval(evalStr + ".push([]);") - 1;
             }
-            evalStr += `[${key}']`;
+            evalStr += `[${key}]`;
             if (j !== keys.length - 1 && eval("typeof " + evalStr) === "undefined") {
               eval(evalStr + " = [];");
             }


### PR DESCRIPTION
Removes SyntaxError (Unexpected string) caused when calling cb.__call(..); on an app-only auth request.